### PR TITLE
fix: changing file extension

### DIFF
--- a/packages/rollup-plugin-module-federation/package.json
+++ b/packages/rollup-plugin-module-federation/package.json
@@ -21,12 +21,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.cjs"
     }
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/esm/index.mjs",
   "files": [
     "dist",
     "src",

--- a/packages/rollup-plugin-module-federation/rollup.config.mjs
+++ b/packages/rollup-plugin-module-federation/rollup.config.mjs
@@ -10,6 +10,7 @@ const config = ({ outputFormat }) => ({
   },
   output: {
     dir: `dist/${outputFormat}`,
+    entryFileNames: `[name].${outputFormat === 'esm' ? 'mjs' : 'cjs'}`,
     format: outputFormat,
   },
   plugins: [


### PR DESCRIPTION
This is to fix the following error:
```sh
[!] Error: require() of ES Module /home/projects/webpack-webpack-js-org-oniddk/node_modules/rollup-plugin-module-federation/dist/cjs/index.js from /home/projects/webpack-webpack-js-org-oniddk/rollup.config.js not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /home/projects/webpack-webpack-js-org-oniddk/node_modules/rollup-plugin-module-federation/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```